### PR TITLE
fix: simple replace for the hash function x-wav to wav

### DIFF
--- a/js/digestMessage.js
+++ b/js/digestMessage.js
@@ -1,6 +1,7 @@
 // Hash audioData function
 
 export async function digestMessage(message) {
+  message = message.replace("audio/x-wav", "audio/wav");
   const msgUint8 = new TextEncoder().encode(message); // encode as (utf-8) Uint8Array
   const hashBuffer = await crypto.subtle.digest("SHA-1", msgUint8); // hash the message
   const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array


### PR DESCRIPTION
I've tested this on my windows and mac, across different browsers, do the same i think it works for the hash, this only addresses wav obviously 